### PR TITLE
Fixing filter middleware

### DIFF
--- a/src/app/middleware/filterMiddleware.js
+++ b/src/app/middleware/filterMiddleware.js
@@ -14,7 +14,7 @@ const filterMiddleware = store => next => action => {
             let matchingCardsById = {};
 
             Object.keys(cardsById).forEach(cardId => {
-              if (cardsById[cardId].text.toLowerCase().includes(currFilter.toLowerCase())) {
+              if ((cardsById[cardId].text || '').toLowerCase().includes(currFilter.toLowerCase())) {
                 matchingCardsById[cardId] = cardsById[cardId];
               }
             });


### PR DESCRIPTION
When creating a new session there is the possibility to not have all the cards data, therefor the middleware fails due to `toLowerCase of undefined`